### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,10 @@ If you have discovered a security vulnerability in this open-source project, i a
 Please send the details of the vulnerability to firaolapp@gmail.com. i will review and address the issue as soon as possible.
 Thank you for helping us keep our project secure!
 
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in social-media-skeleton please disclose it via [our huntr page](https://huntr.dev/repos/fobybus/social-media-skeleton/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of social-media-skeleton.


### PR DESCRIPTION
As requested through the platform by @fobybus, this will point your security policy to [huntr.dev](https://huntr.dev/repos/fobybus/social-media-skeleton})